### PR TITLE
Add Romanian (ro) localization

### DIFF
--- a/Sources/units-swift/Localizable.bundle/ro.lproj/Localizable.strings
+++ b/Sources/units-swift/Localizable.bundle/ro.lproj/Localizable.strings
@@ -1,0 +1,139 @@
+// Area
+"ha" = "ha";
+"ha_full" = "Hectar";
+
+"acre" = "acru";
+"acre_full" = "Acru";
+
+"decare" = "daa";
+"decare_full" = "Decare";
+
+"feddan" = "feddan";
+"feddan_full" = "Feddan";
+
+// Length
+"in" = "in";
+"in_full" = "Inch";
+
+"ft" = "ft";
+"ft_full" = "Picior";
+
+"mile" = "mi";
+"mile_full" = "Milă";
+
+"mm" = "mm";
+"mm_full" = "Milimetru";
+
+"cm" = "cm";
+"cm_full" = "Centimetru";
+
+"m" = "m";
+"m_full" = "Metru";
+
+"km" = "km";
+"km_full" = "Kilometru";
+
+// Weight
+"kg" = "kg";
+"kg_full" = "Kilogram";
+
+"pound" = "lb";
+"pound_full" = "Livră";
+
+"centner" = "q";
+"centner_full" = "Chintal";
+
+"ton" = "t";
+"ton_full" = "Tonă";
+
+// Liquids
+"pint" = "pinte";
+"pint_full" = "Pintă";
+
+"quart" = "quart";
+"quart_full" = "Quart";
+
+"liter" = "l";
+"liter_full" = "Litru";
+
+"british_gallon" = "gal";
+"british_gallon_full" = "Galon britanic";
+
+"american_gallon" = "gal";
+"american_gallon_full" = "Galon american";
+
+"bushel" = "bu";
+"bushel_full" = "Bușel";
+
+// Temperature
+"celsius" = "°C";
+"celsius_full" = "Grade Celsius";
+
+"fahrenheit" = "°F";
+"fahrenheit_full" = "Grade Fahrenheit";
+
+// Productivity
+"bushel_per_acre" = "bu/acru";
+"bushel_per_acre_full" = "Bușel pe acru";
+
+"ton_per_ha" = "t/ha";
+"ton_per_ha_full" = "Tonă pe hectar";
+
+"centner_per_ha" = "q/ha";
+"centner_per_ha_full" = "Chintal pe hectar";
+
+"us_ton_per_acre" = "t/acru";
+"us_ton_per_acre_full" = "Tonă americană pe acru";
+
+"kg_per_decare" = "kg/daa";
+"kg_per_decare_full" = "Kilogram pe decare";
+
+"tonn_per_acre" = "t/acru";
+"tonn_per_acre_full" = "Tonă pe acru";
+
+"kg_per_ha" = "kg/ha";
+"kg_per_ha_full" = "Kilogram pe hectar";
+
+"kg_per_acre" = "kg/acru";
+"kg_per_acre_full" = "Kilogram pe acru";
+
+"tonn_per_feddan" = "t/feddan";
+"tonn_per_feddan_full" = "Tonă pe feddan";
+
+// Speed
+"m_per_sec" = "m/s";
+"m_per_sec_full" = "Metru pe secundă";
+
+"mile_per_hour" = "mi/h";
+"mile_per_hour_full" = "Milă pe oră";
+
+"km_per_hour" = "km/h";
+"km_per_hour_full" = "Kilometru pe oră";
+
+// Fuel
+"liter_per_ha" = "l/ha";
+"liter_per_ha_full" = "Litru pe hectar";
+
+"american_pint_per_acre" = "pinte/acru";
+"american_pint_per_acre_full" = "Pintă americană pe acru";
+
+"american_quart" = "quarts/acru";
+"american_quart_full" = "Quart american pe acru";
+
+"american_gallon_per_acre" = "gal/acru";
+"american_gallon_per_acre_full" = "Galon american pe acru";
+
+"liter_per_100km" = "l/100km";
+"liter_per_100km_full" = "Litru la 100 km";
+
+"km_per_liter" = "km/l";
+"km_per_liter_full" = "Kilometru pe litru";
+
+"mile_per_us_gallon" = "mpg";
+"mile_per_us_gallon_full" = "Milă pe galon american";
+
+"mile_per_uk_gallon" = "mpg";
+"mile_per_uk_gallon_full" = "Milă pe galon britanic";
+
+"fluid_ounce_per_acre" = "fl oz/acru";
+"fluid_ounce_per_acre_full" = "Uncie fluidă pe acru";

--- a/Sources/units-swift/Localizable.bundle/ro.lproj/Localizable.strings
+++ b/Sources/units-swift/Localizable.bundle/ro.lproj/Localizable.strings
@@ -2,7 +2,7 @@
 "ha" = "ha";
 "ha_full" = "Hectar";
 
-"acre" = "acru";
+"acre" = "ac";
 "acre_full" = "Acru";
 
 "decare" = "daa";
@@ -47,10 +47,10 @@
 "ton_full" = "Tonă";
 
 // Liquids
-"pint" = "pinte";
+"pint" = "pt";
 "pint_full" = "Pintă";
 
-"quart" = "quart";
+"quart" = "qt";
 "quart_full" = "Quart";
 
 "liter" = "l";
@@ -73,7 +73,7 @@
 "fahrenheit_full" = "Grade Fahrenheit";
 
 // Productivity
-"bushel_per_acre" = "bu/acru";
+"bushel_per_acre" = "bu/ac";
 "bushel_per_acre_full" = "Bușel pe acru";
 
 "ton_per_ha" = "t/ha";
@@ -82,19 +82,19 @@
 "centner_per_ha" = "q/ha";
 "centner_per_ha_full" = "Chintal pe hectar";
 
-"us_ton_per_acre" = "t/acru";
+"us_ton_per_acre" = "t/ac";
 "us_ton_per_acre_full" = "Tonă americană pe acru";
 
 "kg_per_decare" = "kg/daa";
 "kg_per_decare_full" = "Kilogram pe decare";
 
-"tonn_per_acre" = "t/acru";
+"tonn_per_acre" = "t/ac";
 "tonn_per_acre_full" = "Tonă pe acru";
 
 "kg_per_ha" = "kg/ha";
 "kg_per_ha_full" = "Kilogram pe hectar";
 
-"kg_per_acre" = "kg/acru";
+"kg_per_acre" = "kg/ac";
 "kg_per_acre_full" = "Kilogram pe acru";
 
 "tonn_per_feddan" = "t/feddan";
@@ -104,7 +104,7 @@
 "m_per_sec" = "m/s";
 "m_per_sec_full" = "Metru pe secundă";
 
-"mile_per_hour" = "mi/h";
+"mile_per_hour" = "mph";
 "mile_per_hour_full" = "Milă pe oră";
 
 "km_per_hour" = "km/h";
@@ -114,13 +114,13 @@
 "liter_per_ha" = "l/ha";
 "liter_per_ha_full" = "Litru pe hectar";
 
-"american_pint_per_acre" = "pinte/acru";
+"american_pint_per_acre" = "pt/ac";
 "american_pint_per_acre_full" = "Pintă americană pe acru";
 
-"american_quart" = "quarts/acru";
+"american_quart" = "qt/ac";
 "american_quart_full" = "Quart american pe acru";
 
-"american_gallon_per_acre" = "gal/acru";
+"american_gallon_per_acre" = "gal/ac";
 "american_gallon_per_acre_full" = "Galon american pe acru";
 
 "liter_per_100km" = "l/100km";
@@ -135,5 +135,5 @@
 "mile_per_uk_gallon" = "mpg";
 "mile_per_uk_gallon_full" = "Milă pe galon britanic";
 
-"fluid_ounce_per_acre" = "fl oz/acru";
+"fluid_ounce_per_acre" = "fl oz/ac";
 "fluid_ounce_per_acre_full" = "Uncie fluidă pe acru";

--- a/Tests/units-swiftTests/LocalizatorTests.swift
+++ b/Tests/units-swiftTests/LocalizatorTests.swift
@@ -430,6 +430,50 @@ class LocalizatorTests: XCTestCase {
         }
     }
 
+    func testLocalizatorRO() {
+        do {
+            let localizator = try UnitsLocalizator(language: "ro")
+            try self.checkAllLocalizations(language: "ro")
+
+            XCTAssertEqual(localizator.ha.short, "ha")
+            XCTAssertEqual(localizator.ha.full, "Hectar")
+            XCTAssertEqual(localizator.acre.short, "acru")
+            XCTAssertEqual(localizator.acre.full, "Acru")
+            XCTAssertEqual(localizator.in.short, "in")
+            XCTAssertEqual(localizator.in.full, "Inch")
+            XCTAssertEqual(localizator.ft.short, "ft")
+            XCTAssertEqual(localizator.ft.full, "Picior")
+            XCTAssertEqual(localizator.mile.short, "mi")
+            XCTAssertEqual(localizator.mile.full, "Milă")
+            XCTAssertEqual(localizator.mm.short, "mm")
+            XCTAssertEqual(localizator.mm.full, "Milimetru")
+            XCTAssertEqual(localizator.cm.short, "cm")
+            XCTAssertEqual(localizator.cm.full, "Centimetru")
+            XCTAssertEqual(localizator.m.short, "m")
+            XCTAssertEqual(localizator.m.full, "Metru")
+            XCTAssertEqual(localizator.km.short, "km")
+            XCTAssertEqual(localizator.km.full, "Kilometru")
+            XCTAssertEqual(localizator.kg.short, "kg")
+            XCTAssertEqual(localizator.kg.full, "Kilogram")
+            XCTAssertEqual(localizator.ton.short, "t")
+            XCTAssertEqual(localizator.ton.full, "Tonă")
+            XCTAssertEqual(localizator.liter.short, "l")
+            XCTAssertEqual(localizator.liter.full, "Litru")
+            XCTAssertEqual(localizator.celsius.short, "°C")
+            XCTAssertEqual(localizator.celsius.full, "Grade Celsius")
+            XCTAssertEqual(localizator.fahrenheit.short, "°F")
+            XCTAssertEqual(localizator.fahrenheit.full, "Grade Fahrenheit")
+            XCTAssertEqual(localizator.tonPerHa.short, "t/ha")
+            XCTAssertEqual(localizator.tonPerHa.full, "Tonă pe hectar")
+            XCTAssertEqual(localizator.kmPerHour.short, "km/h")
+            XCTAssertEqual(localizator.kmPerHour.full, "Kilometru pe oră")
+            XCTAssertEqual(localizator.literPerHa.short, "l/ha")
+            XCTAssertEqual(localizator.literPerHa.full, "Litru pe hectar")
+        } catch let error {
+            XCTFail("error - \(error)")
+        }
+    }
+
     func testLocalizatorAR() {
         do {
             let localizator = try UnitsLocalizator(language: "ar")
@@ -467,7 +511,7 @@ class LocalizatorTests: XCTestCase {
         let localizable = main.path(forResource: "Localizable", ofType: "bundle")
         .flatMap { Bundle(path: $0) }
 
-        let langs = ["de", "ar", "en", "uk", "es", "et", "bg", "cs", "hu", "pl", "ru", "pt"]
+        let langs = ["de", "ar", "en", "uk", "es", "et", "bg", "cs", "hu", "pl", "ru", "pt", "ro"]
         XCTAssertEqual(localizable?.localizations, langs)
         XCTAssertEqual(localizable?.localizations.count, LocalizatorTests.allTests.count - 1)
     }
@@ -485,6 +529,7 @@ class LocalizatorTests: XCTestCase {
         ("testLocalizatorBG", testLocalizatorBG),
         ("testLocalizatorCS", testLocalizatorCS),
         ("testLocalizatorAR", testLocalizatorAR),
+        ("testLocalizatorRO", testLocalizatorRO),
         ("testCheckTestCount", testCheckTestCount)
     ]
 }

--- a/Tests/units-swiftTests/LocalizatorTests.swift
+++ b/Tests/units-swiftTests/LocalizatorTests.swift
@@ -437,7 +437,7 @@ class LocalizatorTests: XCTestCase {
 
             XCTAssertEqual(localizator.ha.short, "ha")
             XCTAssertEqual(localizator.ha.full, "Hectar")
-            XCTAssertEqual(localizator.acre.short, "acru")
+            XCTAssertEqual(localizator.acre.short, "ac")
             XCTAssertEqual(localizator.acre.full, "Acru")
             XCTAssertEqual(localizator.in.short, "in")
             XCTAssertEqual(localizator.in.full, "Inch")

--- a/Tests/units-swiftTests/TestLocalizator.swift
+++ b/Tests/units-swiftTests/TestLocalizator.swift
@@ -49,6 +49,10 @@ struct TestLocalizator: Localizator {
     var tonPerHa: Localization { return .init(short: "", full: "") }
     var centnerPerHa: Localization { return .init(short: "", full: "") }
     var kgPerDecare: Localization { return .init(short: "", full: "") }
+    var tonnPerAcre: Localization { return .init(short: "", full: "") }
+    var kgPerHa: Localization { return .init(short: "", full: "") }
+    var kgPerAcre: Localization { return .init(short: "", full: "") }
+    var tonnPerFeddan: Localization { return .init(short: "", full: "") }
 
     // MARK: Speed
     var mPerSec: Localization { return .init(short: "", full: "") }
@@ -60,6 +64,7 @@ struct TestLocalizator: Localizator {
     var americanQuart: Localization { return .init(short: "", full: "") }
     var literPerHa: Localization { return .init(short: "", full: "") }
     var americanGallonPerAcre: Localization { .init(short: "", full: "") }
+    var fluidOuncePerAcre: Localization { return .init(short: "", full: "") }
 
     var milePerUsGallon: Localization { return .init(short: "", full: "") }
     var kmPerLiter: Localization { return .init(short: "", full: "") }

--- a/Tests/units-swiftTests/UnitTypeTests.swift
+++ b/Tests/units-swiftTests/UnitTypeTests.swift
@@ -227,10 +227,10 @@ class UnitTypeTests: XCTestCase {
         }
 
         do {
-            let units = try Units(units: [:], language: "ro")
+            let units = try Units(units: [:], language: "xx")
             XCTFail("units - \(units)")
         } catch let error {
-            XCTAssertEqual("\(error)", "notFound(type: \"area\", inTable: [:])")
+            XCTAssertTrue("\(error)".contains("unsupportedLanguage(language: \"xx\""))
         }
     }
 

--- a/Tests/units-swiftTests/UnitTypeTests.swift
+++ b/Tests/units-swiftTests/UnitTypeTests.swift
@@ -211,10 +211,10 @@ class UnitTypeTests: XCTestCase {
 
     func testDefaultUnitsError() {
         do {
-            let units = try Units.default(language: "ro")
+            let units = try Units.default(language: "xx")
             XCTFail("units - \(units)")
         } catch let error {
-            XCTAssertEqual("\(error)", #"localization(error: units_swift.UnitsLocalizator.E.unsupportedLanguage(language: "ro", supported: Optional(["de", "ar", "en", "uk", "es", "et", "bg", "cs", "hu", "pl", "ru", "pt"])))"#)
+            XCTAssertTrue("\(error)".contains("unsupportedLanguage(language: \"xx\""))
         }
     }
 
@@ -230,7 +230,7 @@ class UnitTypeTests: XCTestCase {
             let units = try Units(units: [:], language: "ro")
             XCTFail("units - \(units)")
         } catch let error {
-            XCTAssertEqual("\(error)", #"localization(error: units_swift.UnitsLocalizator.E.unsupportedLanguage(language: "ro", supported: Optional(["de", "ar", "en", "uk", "es", "et", "bg", "cs", "hu", "pl", "ru", "pt"])))"#)
+            XCTAssertEqual("\(error)", "notFound(type: \"area\", inTable: [:])")
         }
     }
 


### PR DESCRIPTION
Adds Romanian language support for unit measurements.

## Changes
- Added `ro.lproj/Localizable.strings` with Romanian translations for all unit measurements
- Added `testLocalizatorRO` test covering key unit translations for Romanian locale
- Fixed pre-existing `TestLocalizator` build errors (missing protocol properties: `tonnPerAcre`, `kgPerHa`, `kgPerAcre`, `tonnPerFeddan`, `fluidOuncePerAcre`)
- Updated `testDefaultUnitsError` and `testUnitsError` to reflect that `ro` is now a supported language

All 42 tests pass.

Part of COM-526 (Add Romanian language).